### PR TITLE
Fix for GoogleCASIssuer.cas-issuer.jetstack.io not found due to be empty

### DIFF
--- a/pkg/controller/certificaterequest/certificaterequest_controller.go
+++ b/pkg/controller/certificaterequest/certificaterequest_controller.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
+
 	"github.com/go-logr/logr"
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
@@ -32,7 +34,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
-	"math/rand"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -110,6 +111,7 @@ func (r *CertificateRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result,
 		issuer := api.GoogleCASIssuer{}
 		issuerNamespaceName := types.NamespacedName{
 			Namespace: req.Namespace,
+			Name:      cr.Spec.IssuerRef.Name,
 		}
 		if err := r.Client.Get(ctx, issuerNamespaceName, &issuer); err != nil {
 			log.Error(err, "failed to retrieve GoogleCASIssuer resource", "namespace", req.Namespace, "name", cr.Spec.IssuerRef.Name)


### PR DESCRIPTION
I was getting the following error:

```
2021-01-04T08:19:19.642Z	ERROR	controller.CertificateRequest	failed to retrieve GoogleCASIssuer resource	{"certificaterequest": "google-cas/google-cas-hxfrh", "namespace": "google-cas", "name": "googlecasissuer", "error": "GoogleCASIssuer.cas-issuer.jetstack.io \"\" not found"}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.2.0/zapr.go:132
github.com/jetstack/google-cas-issuer/pkg/controller/certificaterequest.(*CertificateRequestReconciler).Reconcile
	/workspace/pkg/controller/certificaterequest/certificaterequest_controller.go:115
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:235
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:209
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.2/pkg/internal/controller/controller.go:188
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.19.0/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.19.0/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.19.0/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
	/go/pkg/mod/k8s.io/apimachinery@v0.19.0/pkg/util/wait/wait.go:90
```

This PR fixes that error