### PR TITLE
Typo fixes in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Firstly, create a Google Cloud IAM service account. This service account will be
 gcloud iam service-accounts create my-sa
 ```
 
-Apply the appropriate IAM bindings to this account. This example permits the least privilege, to create  certificates (ie `privateca.certificates.create`) from a specified suboordinate CA (`my-sub-ca`), but you can use other roles as necessary (see [Predefined Roles](https://cloud.google.com/certificate-authority-service/docs/reference/permissions-and-roles#predefined_roles) for more details).
+Apply the appropriate IAM bindings to this account. This example permits the least privilege, to create  certificates (ie `roles/privateca.certificates.create`) from a specified suboordinate CA (`my-sub-ca`), but you can use other roles as necessary (see [Predefined Roles](https://cloud.google.com/certificate-authority-service/docs/reference/permissions-and-roles#predefined_roles) for more details).
 
 ```shell
-gcloud beta privateca subordinates add-iam-policy-binding my-sub-ca --role=privateca.certificateRequester --member='serviceAccount:my-sa@project-id.iam.gserviceaccount.com'
+gcloud beta privateca subordinates add-iam-policy-binding my-sub-ca --role=roles/privateca.certificateRequester --member='serviceAccount:my-sa@project-id.iam.gserviceaccount.com'
 ```
 
 #### Inside GKE with workload identity


### PR DESCRIPTION
Some small typo fixes I encountered when doing a run-through of the CAS issuer