### PR TITLE
Automatic release pipelines

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
           push: true
           tags: |
             quay.io/jetstack/cert-manager-google-cas-issuer:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: quay.io/jetstack/cert-manager-google-cas-issuer
+          tag-semver: |
+            {{version}}
+            {{major}}.{{minor}}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: jake_jetstack
+          password: ${{ secrets.QUAY_ENCRYPTED_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        if: ${{ !env.ACT }}
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+
+
+  prepare_release:
+    runs-on: ubuntu-latest
+    container: golang:1.15
+    steps:
+      -
+        name: extract version
+        id: extract_version
+        run: echo ::set-output name=VERSION::$(echo ${GITHUB_REF##*/})
+      -
+        name: install controller-gen
+        working-directory: /
+        env:
+          GO111MODULE: on
+        run: go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5
+      -
+        name: install kustomize
+        working-directory: /
+        env:
+          GO111MODULE: on
+        run: go get sigs.k8s.io/kustomize/kustomize/v3
+      -
+        name: checkout repository
+        uses: actions/checkout@v2
+      -
+        name: generate manifests
+        run: make manifests
+      -
+        name: generate deployment manifests
+        id: deploy
+        shell: bash
+        env:
+          IMG: quay.io/jetstack/cert-manager-google-cas-issuer
+        run: |
+          pushd config/manager
+          kustomize edit set image controller=$IMG:${GITHUB_REF##*/}
+          popd
+          kustomize build config/default | tee google-cas-issuer-${GITHUB_REF##*/}.yaml
+      -
+        name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: false
+          body: |
+            docker images are available at `quay.io/jetstack/cert-manager-google-cas-issuer:${{ steps.extract_version.outputs.VERSION }}
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: ./google-cas-issuer-${{ steps.extract_version.outputs.VERSION }}.yaml
+          asset_name: google-cas-issuer-${{ steps.extract_version.outputs.VERSION }}.yaml
+          asset_content_type: application/x-yaml
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+on: [pull_request, push]
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    container: golang:1.15
+    steps:
+      - name: install kubebuilder
+        run: |
+          os=$(go env GOOS)
+          arch=$(go env GOARCH)
+          curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
+          mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
+          export PATH=$PATH:/usr/local/kubebuilder/bin
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Run tests
+        run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o google-cas-issuer main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -v -o google-cas-issuer main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ google-cas-issuer: generate fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go
+	go run ./main.go --zap-devel=true
 
 # Install CRDs into a cluster
 install: manifests

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: cas-mk2-system
+namespace: cert-manager
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: cas-mk2-
+namePrefix: devel-
 
 # Labels to add to all resources and selectors.
 #commonLabels:
@@ -28,7 +28,7 @@ patchesStrategicMerge:
   # Protect the /metrics endpoint by putting it behind auth.
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+#- manager_auth_proxy_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in 
 # crd/kustomization.yaml

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,8 +3,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
-  namespace: system
+  name: google-cas-issuer
+  namespace: cert-manager
 spec:
   template:
     spec:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: google-cas
+  newName: quay.io/jetstack/cert-manager-google-cas-issuer
+  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,34 +1,33 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
+  name: cert-manager
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
-  namespace: system
+  name: google-cas-issuer
+  namespace: cert-manager
   labels:
-    control-plane: controller-manager
+    app: cert-manager-google-cas-issuer
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app: cert-manager-google-cas-issuer
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        app: cert-manager-google-cas-issuer
     spec:
       containers:
       - command:
-        - /manager
+        - /google-cas-issuer
         args:
         - --enable-leader-election
+        - --zap-devel=true
         image: controller:latest
-        name: manager
+        name: google-cas-issuer
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
This sets up Github Actions to automatically build/push images on releases, run tests on PRs and keep the :latest tag up to date with the main branch.