### PR TITLE
Add the google-cas-issuer helm chart

### DIFF
--- a/deploy/google-cas-issuer/Chart.yaml
+++ b/deploy/google-cas-issuer/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+engine: gotpl
+name: google-cas-issuer
+version: 1.1.0
+appVersion: 0.1.0

--- a/deploy/google-cas-issuer/crds/crds.cas-issuer.jetstack.io_googlecasclusterissuers.yaml
+++ b/deploy/google-cas-issuer/crds/crds.cas-issuer.jetstack.io_googlecasclusterissuers.yaml
@@ -1,0 +1,121 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
+  name: googlecasclusterissuers.cas-issuer.jetstack.io
+spec:
+  group: cas-issuer.jetstack.io
+  names:
+    kind: GoogleCASClusterIssuer
+    listKind: GoogleCASClusterIssuerList
+    plural: googlecasclusterissuers
+    singular: googlecasclusterissuer
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: GoogleCASClusterIssuer is the Schema for the googlecasclusterissuers
+        API
+      properties:
+        apiVersion:
+          description: "APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          type: string
+        kind:
+          description: "Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GoogleCASIssuerSpec defines the desired state of GoogleCASIssuer
+          properties:
+            certificateAuthorityID:
+              description: CertificateAuthorityID is The ID of the Google Private
+                certificate authority that will sign certificates
+              type: string
+            credentials:
+              description: Credentials is a reference to a Kubernetes Secret Key that
+                contains Google Service Account Credentials
+              properties:
+                key:
+                  description: The key of the entry in the Secret resource's `data`
+                    field to be used. Some instances of this field may be defaulted,
+                    in others it may be required.
+                  type: string
+                name:
+                  description: "Name of the resource being referred to. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                  type: string
+              required:
+                - name
+              type: object
+            location:
+              description: Location is the Google Cloud Project Location
+              type: string
+            project:
+              description: Project is the Google Cloud Project ID
+              type: string
+          type: object
+        status:
+          description: GoogleCASIssuerStatus defines the observed state of GoogleCASIssuer
+          properties:
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for a
+                  CAS Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    allOf:
+                      - enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      - enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    enum:
+                      - Ready
+                    type: string
+                required:
+                  - status
+                  - type
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/google-cas-issuer/crds/crds.cas-issuer.jetstack.io_googlecasissuers.yaml
+++ b/deploy/google-cas-issuer/crds/crds.cas-issuer.jetstack.io_googlecasissuers.yaml
@@ -1,0 +1,120 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.2
+  name: googlecasissuers.cas-issuer.jetstack.io
+spec:
+  group: cas-issuer.jetstack.io
+  names:
+    kind: GoogleCASIssuer
+    listKind: GoogleCASIssuerList
+    plural: googlecasissuers
+    singular: googlecasissuer
+  scope: ""
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: GoogleCASIssuer is the Schema for the googlecasissuers API
+      properties:
+        apiVersion:
+          description: "APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          type: string
+        kind:
+          description: "Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GoogleCASIssuerSpec defines the desired state of GoogleCASIssuer
+          properties:
+            certificateAuthorityID:
+              description: CertificateAuthorityID is The ID of the Google Private
+                certificate authority that will sign certificates
+              type: string
+            credentials:
+              description: Credentials is a reference to a Kubernetes Secret Key that
+                contains Google Service Account Credentials
+              properties:
+                key:
+                  description: The key of the entry in the Secret resource's `data`
+                    field to be used. Some instances of this field may be defaulted,
+                    in others it may be required.
+                  type: string
+                name:
+                  description: "Name of the resource being referred to. More info:
+                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                  type: string
+              required:
+                - name
+              type: object
+            location:
+              description: Location is the Google Cloud Project Location
+              type: string
+            project:
+              description: Project is the Google Cloud Project ID
+              type: string
+          type: object
+        status:
+          description: GoogleCASIssuerStatus defines the observed state of GoogleCASIssuer
+          properties:
+            conditions:
+              items:
+                description: IssuerCondition contains condition information for a
+                  CAS Issuer.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    allOf:
+                      - enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      - enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    enum:
+                      - Ready
+                    type: string
+                required:
+                  - status
+                  - type
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/google-cas-issuer/templates/_helpers.tpl
+++ b/deploy/google-cas-issuer/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "google-cas-issuer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "google-cas-issuer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "google-cas-issuer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "google-cas-issuer.labels" -}}
+helm.sh/chart: {{ include "google-cas-issuer.chart" . }}
+{{ include "google-cas-issuer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "google-cas-issuer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "google-cas-issuer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: "controller"
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "google-cas-issuer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "google-cas-issuer.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/google-cas-issuer/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "google-cas-issuer.fullname" . }}
+  labels:
+    {{- include "google-cas-issuer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "google-cas-issuer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9402"
+      labels:
+        {{- include "google-cas-issuer.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "google-cas-issuer.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          - --enable-leader-election
+          - --cluster-resource-namespace={{ .Values.secretsNamespace }}
+          - --metrics-addr=:9402
+          ports:
+            - name: metrics
+              containerPort: 9402
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/google-cas-issuer/templates/service.yaml
+++ b/deploy/google-cas-issuer/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "google-cas-issuer.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "google-cas-issuer.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 9402
+      targetPort: 9402
+  selector:
+    {{- include "google-cas-issuer.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/google-cas-issuer/templates/serviceaccount.yaml
+++ b/deploy/google-cas-issuer/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "google-cas-issuer.serviceAccountName" . }}
+  labels:
+    {{- include "google-cas-issuer.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/google-cas-issuer/values.yaml
+++ b/deploy/google-cas-issuer/values.yaml
@@ -1,0 +1,31 @@
+# The namespace for secrets in which cluster-scoped resources are found. (default "cert-manager")
+secretsNamespace: cert-manager
+serviceAccount:
+  create: false
+  name: default
+  annotations: {}
+
+image:
+  # tag: v0.1.0
+  repository: quay.io/jetstack/cert-manager-google-cas-issuer
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+imagePullSecrets: {}
+securityContext: {}
+podSecurityContext: {}
+
+resources:
+  {}
+  # requests:
+  #   cpu: 10m
+  #   memory: 32Mi
+
+nodeSelector: {}
+affinity: {}
+tolerations: {}
+
+prometheus:
+  # Enables the creation of the ClusterIP service.
+  enabled: true


### PR DESCRIPTION
As part of [the work](https://docs.google.com/document/d/1-iigFCpXbKsscpmjbTkjUJZUognUeXZPGvMrPqo9eXE/edit#) on releasing Jetstack Secure to the Google Marketplace, I created an ad-hoc helm chart for google-cas-issuer in https://github.com/jetstack/jsp-gcm/pull/4. After discussing it during this morning's standup, Jake and I thought it would be better to move this ad-hoc chart to google-cas-issuer repo itself.

This PR is our first draft at creating this helm chart. All the RBAC and service account stuff is still missing.
