### PR TITLE
make: use the SA name "ksa-google-cas-issuer" instead of "default"

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ google-cas-issuer-687685dc46-lrjkc        1/1     Running   0          28h
 Firstly, create a Google Cloud IAM service account. This service account will be used by the CAS Issuer to access the Google Private CA APIs.
 
 ```shell
-gcloud iam service-accounts create my-sa
+gcloud iam service-accounts create sa-google-cas-issuer
 ```
 
 Apply the appropriate IAM bindings to this account. This example permits the least privilege, to create  certificates (ie `roles/privateca.certificates.create`) from a specified suboordinate CA (`my-sub-ca`), but you can use other roles as necessary (see [Predefined Roles](https://cloud.google.com/certificate-authority-service/docs/reference/permissions-and-roles#predefined_roles) for more details).
 
 ```shell
-gcloud beta privateca subordinates add-iam-policy-binding my-sub-ca --role=roles/privateca.certificateRequester --member='serviceAccount:my-sa@project-id.iam.gserviceaccount.com'
+gcloud beta privateca subordinates add-iam-policy-binding my-sub-ca --role=roles/privateca.certificateRequester --member='serviceAccount:sa-google-cas-issuer@project-id.iam.gserviceaccount.com'
 ```
 
 #### Inside GKE with workload identity
@@ -122,7 +122,7 @@ enabled. Create a kubernetes service account for the CAS Issuer:
 
 ```shell
 # Create a new Kubernetes service account
-kubectl create serviceaccount -n cert-manager my-ksa
+kubectl create serviceaccount -n cert-manager ksa-google-cas-issuer
 ```
 
 Bind the Kubernetes service account to the Google Cloud service account:
@@ -130,13 +130,13 @@ Bind the Kubernetes service account to the Google Cloud service account:
 ```shell
 gcloud iam service-accounts add-iam-policy-binding \
   --role roles/iam.workloadIdentityUser \
-  --member "serviceAccount:project-id.svc.id.goog[cert-manager/my-ksa]" \
-  my-sa@project-id.iam.gserviceaccount.com
+  --member "serviceAccount:project-id.svc.id.goog[cert-manager/ksa-google-cas-issuer]" \
+  sa-google-cas-issuer@project-id.iam.gserviceaccount.com
 
 kubectl annotate serviceaccount \
   --namespace cert-manager \
-  my-ksa \
-  iam.gke.io/gcp-service-account=my-sa@project-id.iam.gserviceaccount.com
+  ksa-google-cas-issuer \
+  iam.gke.io/gcp-service-account=sa-google-cas-issuer@project-id.iam.gserviceaccount.com
 ```
 
 #### Outside GKE or in an unrelated GCP project
@@ -144,7 +144,8 @@ kubectl annotate serviceaccount \
 Create a key for the service account and download it to a local JSON file.
 
 ```shell
-gcloud iam service-accounts keys create project-name-keyid.json --iam-account my-sa@project-id.iam.gserviceaccount.com
+gcloud iam service-accounts keys create project-name-keyid.json \
+  --iam-account sa-google-cas-issuer@project-id.iam.gserviceaccount.com
 ```
 
 The service account key should be stored in a Kubernetes secret in your cluster so it can be accessed by the CAS Issuer controller.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: cert-manager-google-cas-issuer
     spec:
+      serviceAccountName: ksa-google-cas-issuer
       containers:
       - command:
         - /google-cas-issuer

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -7,6 +7,6 @@ roleRef:
   kind: Role
   name: leader-election-role
 subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: system
+  - kind: ServiceAccount
+    name: ksa-google-cas-issuer
+    namespace: cert-manager

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -7,6 +7,6 @@ roleRef:
   kind: ClusterRole
   name: google-cas-issuer-role
 subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: cert-manager
+  - kind: ServiceAccount
+    name: ksa-google-cas-issuer
+    namespace: cert-manager


### PR DESCRIPTION
This PR makes sure that the SA required in the `make deploy` step is the same as the Kubernetes service account we create in the readme.

Signed-off-by: Maël Valais <mael@vls.dev>