### PR TITLE
Update README to reference CAS instead of Private CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Google Certificate Authority Service Issuer for cert-manager
 
 This repository contains an [external Issuer](https://cert-manager.io/docs/contributing/external-issuers/)
-for cert-manager that issues certificates using Google's private
-[Certificate Authority Service](https://cloud.google.com/certificate-authority-service/).
+for cert-manager that issues certificates using [Google Cloud
+Certificate Authority Service (CAS)](https://cloud.google.com/certificate-authority-service/), using managed private CAs to issue certificates.
 
 ## Getting started
 
 ### Prerequisites
 
-#### Private CA-enabled GCP project
+#### CAS-enabled GCP project
 
-Enable the private CA API in your GCP project by following the
+Enable the Certificate Authority API (`privateca.googleapis.com`) in your GCP project by following the
 [official documentation](https://cloud.google.com/certificate-authority-service/docs/quickstart).
 
 ####  CAS-managed CAs
@@ -102,13 +102,13 @@ google-cas-issuer-687685dc46-lrjkc        1/1     Running   0          28h
 
 ### Setting up Google Cloud IAM
 
-Firstly, create a Google Cloud IAM service account. This service account will be used by the CAS Issuer to access the Google Private CA APIs.
+Firstly, create a Google Cloud IAM service account. This service account will be used by the CAS Issuer to access the Google Cloud CAS APIs.
 
 ```shell
 gcloud iam service-accounts create my-sa
 ```
 
-Apply the appropriate IAM bindings to this account. This example permits the least privilege, to create  certificates (ie `roles/privateca.certificates.create`) from a specified suboordinate CA (`my-sub-ca`), but you can use other roles as necessary (see [Predefined Roles](https://cloud.google.com/certificate-authority-service/docs/reference/permissions-and-roles#predefined_roles) for more details).
+Apply the appropriate IAM bindings to this account. This example permits the least privilege, to create certificates (ie `roles/privateca.certificates.create`) from a specified suboordinate CA (`my-sub-ca`), but you can use other roles as necessary (see [Predefined Roles](https://cloud.google.com/certificate-authority-service/docs/reference/permissions-and-roles#predefined_roles) for more details).
 
 ```shell
 gcloud beta privateca subordinates add-iam-policy-binding my-sub-ca --role=roles/privateca.certificateRequester --member='serviceAccount:my-sa@project-id.iam.gserviceaccount.com'


### PR DESCRIPTION
This clarifies that the name of the API is Certificate Authority Service. I removed most mentions of "private" except when referencing the name of the API endpoint or IAM roles.