### PR TITLE
CI: kubebuilder and envtest not needed, update to Go 1.17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: install kubebuilder
-        run: |
-          os=$(go env GOOS)
-          arch=$(go env GOARCH)
-          curl -L https://go.kubebuilder.io/dl/2.3.1/${os}/${arch} | tar -xz -C /tmp/
-          sudo mv /tmp/kubebuilder_2.3.1_${os}_${arch} /usr/local/kubebuilder
-          export PATH=$PATH:/usr/local/kubebuilder/bin
-      -
         name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: '^1.17'
       -
         name: Checkout
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -147,4 +147,3 @@ KUBECTL=$(GOBIN)/kubectl
 else
 KUBECTL=$(shell which kubectl)
 endif
-


### PR DESCRIPTION
Unblocks #54 