### PR TITLE
Helm Chart fixes

### DIFF
--- a/deploy/charts/google-cas-issuer/Chart.yaml
+++ b/deploy/charts/google-cas-issuer/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/jetstack/google-cas-issuer
 
 appVersion: v0.6.1
-version: v0.6.1
+version: v0.6.2

--- a/deploy/charts/google-cas-issuer/Chart.yaml
+++ b/deploy/charts/google-cas-issuer/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 sources:
 - https://github.com/jetstack/google-cas-issuer
 
-appVersion: v0.6.1
+appVersion: v0.6.2
 version: v0.6.2

--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -1,6 +1,6 @@
 # cert-manager-google-cas-issuer
 
-![Version: v0.6.1](https://img.shields.io/badge/Version-v0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
+![Version: v0.6.2](https://img.shields.io/badge/Version-v0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
 
 A Helm chart for jetstack/google-cas-issuer
 
@@ -31,4 +31,5 @@ A Helm chart for jetstack/google-cas-issuer
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the google-cas-issuer container image. |
 | replicaCount | int | `1` | Number of replicas of google-cas-issuer to run. |
 | resources | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` | Optional annotations to add to the service account |
 

--- a/deploy/charts/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/charts/google-cas-issuer/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         args:
           - --enable-leader-election
           - --log-level={{.Values.app.logLevel}}
+          - --metrics-addr=:{{.Values.app.metrics.port}}
 
         resources:
           {{- toYaml .Values.resources | indent 12 }}

--- a/deploy/charts/google-cas-issuer/templates/serviceaccount.yaml
+++ b/deploy/charts/google-cas-issuer/templates/serviceaccount.yaml
@@ -4,3 +4,5 @@ metadata:
   name: {{ include "cert-manager-google-cas-issuer.name" . }}
   labels:
 {{ include "cert-manager-google-cas-issuer.labels" . | indent 4 }}
+  annotations:
+{{ include "cert-manager-google-cas-issuer.serviceAccount.annotations" . | indent 4 }}

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -12,6 +12,11 @@ image:
 # -- Optional secrets used for pulling the google-cas-issuer container image.
 imagePullSecrets: []
 
+serviceAccount:
+  # -- Optional annotations to add to the service account
+  annotations: {}
+
+
 app:
     # -- Verbosity of google-cas-issuer logging.
   logLevel: 1 # 1-5


### PR DESCRIPTION
We've got this set up and working in our gke cluster (with workload identity), seems to be working great, thanks for all the work!

I've got two usability fixes for the Helm chart:

- We need to be able to add annotations to the ServiceAccount to enable Workload Identity (Step 7 [here](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to))
- The metrics port set in `values.yaml` wasn't being passed to the binary, so it was defaulting to listening on `:8080`