### PR TITLE
 Fix helm chart image tag (attempt 2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ vet:
 helm-docs: $(BINDIR)/helm-docs # verify helm-docs
 	./hack/verify-helm-docs.sh
 
+.PHONY: update-helm-docs
+update-helm-docs: $(BINDIR)/helm-docs # update helm-docs
+	./hack/update-helm-docs.sh
+
 # Generate code
 generate: depend
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -27,7 +27,7 @@ A Helm chart for jetstack/google-cas-issuer
 | app.metrics.port | int | `9402` | Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'. |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-google-cas-issuer"` | Target image repository. |
-| image.tag | string | `"v0.6.0"` | Target image version tag. |
+| image.tag | string | `"0.6.0"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the google-cas-issuer container image. |
 | replicaCount | int | `1` | Number of replicas of google-cas-issuer to run. |
 | resources | object | `{}` |  |

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -5,7 +5,7 @@ image:
   # -- Target image repository.
   repository: quay.io/jetstack/cert-manager-google-cas-issuer
   # -- Target image version tag.
-  tag: v0.6.0
+  tag: 0.6.0
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 

--- a/hack/verify-helm-docs.sh
+++ b/hack/verify-helm-docs.sh
@@ -29,7 +29,7 @@ $HELM_DOCS_BIN ${KUBE_ROOT}/deploy/charts/google-cas-issuer -d -l error > ${TEMP
 
 if ! cmp -s "${KUBE_ROOT}/deploy/charts/google-cas-issuer/README.md" "${TEMP_FILE}"; then
   echo "Helm chart README.md is out of date."
-  echo "Please run './hack/update-helm-docs.sh'."
+  echo "Please run 'make update-helm-docs'."
   exit 1
 fi
 


### PR DESCRIPTION
This is based off https://github.com/jetstack/google-cas-issuer/pull/84 and cherry-picks the commit there but includes an update to the helm docs and a QoL fix for updating the docs

This is the second attempt after #89 - this time, using a branch on upstream rather than a fork since the github actions workflow seemed to fail because it was run on a fork. 

When I looked at a recent merged PR (#82 ) I saw it was run using a branch on upstream.