### PR TITLE
Add very useful values common with the main Cert-manager chart

### DIFF
--- a/deploy/charts/google-cas-issuer/Chart.yaml
+++ b/deploy/charts/google-cas-issuer/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 
 name: cert-manager-google-cas-issuer
 type: application

--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -20,16 +20,24 @@ A Helm chart for jetstack/google-cas-issuer
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity | object | `{}` | Kubernetes affinity: constraints for pod assignment |
 | app.approval | object | `{"enabled":true,"subjects":[{"kind":"ServiceAccount","name":"cert-manager","namespace":"cert-manager"}]}` | Handle RBAC permissions for approving Google CAS issuer CertificateRequests. |
 | app.approval.enabled | bool | `true` | enabled determines whether the ClusterRole and ClusterRoleBinding for approval is created. You will want to disable this if you are managing approval RBAC elsewhere from this chart, for example if you create them separately for all installed issuers. |
 | app.approval.subjects | list | `[{"kind":"ServiceAccount","name":"cert-manager","namespace":"cert-manager"}]` | subjects is the subject that the approval RBAC permissions will be bound to. Here we are binding them to cert-manager's ServiceAccount so that the default approve all approver has the permissions to do so. You will want to change this subject to approver-policy's ServiceAccount if using that project (recommended).   https://cert-manager.io/docs/projects/approver-policy   name: cert-manager-approver-policy   namespace: cert-manager |
 | app.logLevel | int | `1` | Verbosity of google-cas-issuer logging. |
 | app.metrics.port | int | `9402` | Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'. |
+| commonLabels | object | `{}` | Labels to apply to all resources |
+| deploymentAnnotations | object | `{}` | Optional additional annotations to add to the google-cas-issuer Deployment |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-google-cas-issuer"` | Target image repository. |
 | image.tag | string | `"0.6.2"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the google-cas-issuer container image. |
+| nodeSelector | object | `{}` | Kubernetes node selector: node labels for pod assignment |
+| podAnnotations | object | `{}` | Optional additional annotations to add to the google-cas-issuer Pods |
+| podLabels | object | `{}` | Optional additional labels to add to the google-cas-issuer Pods |
+| priorityClassName | string | `""` | Optional priority class to be used for the google-cas-issuer pods. |
 | replicaCount | int | `1` | Number of replicas of google-cas-issuer to run. |
-| resources | object | `{}` |  |
+| resources | object | `{}` | Kubernetes pod resource requests/limits for google-cas-issuer. |
 | serviceAccount.annotations | object | `{}` | Optional annotations to add to the service account |
+| tolerations | list | `[]` | Kubernetes pod tolerations for google-cas-issuer |
 

--- a/deploy/charts/google-cas-issuer/templates/_helpers.tpl
+++ b/deploy/charts/google-cas-issuer/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
@@ -23,4 +24,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}

--- a/deploy/charts/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/charts/google-cas-issuer/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "cert-manager-google-cas-issuer.name" . }}
   labels:
 {{ include "cert-manager-google-cas-issuer.labels" . | indent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -13,12 +17,23 @@ spec:
     metadata:
       labels:
         app: {{ include "cert-manager-google-cas-issuer.name" . }}
+        {{- include "cert-manager-google-cas-issuer.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "cert-manager-google-cas-issuer.name" . }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
       containers:
       - name: {{ include "cert-manager-google-cas-issuer.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -31,6 +46,20 @@ spec:
           - --enable-leader-election
           - --log-level={{.Values.app.logLevel}}
           - --metrics-addr=:{{.Values.app.metrics.port}}
-
+        {{- with .Values.resources }}
         resources:
-          {{- toYaml .Values.resources | indent 12 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -12,10 +12,12 @@ image:
 # -- Optional secrets used for pulling the google-cas-issuer container image.
 imagePullSecrets: []
 
+# -- Labels to apply to all resources
+commonLabels: {}
+
 serviceAccount:
   # -- Optional annotations to add to the service account
   annotations: {}
-
 
 app:
     # -- Verbosity of google-cas-issuer logging.
@@ -47,12 +49,44 @@ app:
     # -- Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
     port: 9402
 
+# -- Optional additional annotations to add to the google-cas-issuer Deployment
+deploymentAnnotations: {}
+
+# -- Optional additional annotations to add to the google-cas-issuer Pods
+podAnnotations: {}
+
+# -- Optional additional labels to add to the google-cas-issuer Pods
+podLabels: {}
+
+# -- Kubernetes pod resource requests/limits for google-cas-issuer.
 resources: {}
-  # -- Kubernetes pod resource limits for google-cas-issuer.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
-  # -- Kubernetes pod memory resource requests for google-cas-issuer.
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+# -- Kubernetes node selector: node labels for pod assignment
+nodeSelector: {}
+  # -- Allow scheduling of DaemonSet on linux nodes only
+  # kubernetes.io/os: linux
+
+# -- Kubernetes affinity: constraints for pod assignment
+affinity: {}
+  # nodeAffinity:
+  #  requiredDuringSchedulingIgnoredDuringExecution:
+  #    nodeSelectorTerms:
+  #    - matchExpressions:
+  #      - key: foo.bar.com/role
+  #        operator: In
+  #        values:
+  #        - master
+
+# -- Kubernetes pod tolerations for google-cas-issuer
+tolerations: []
+  # -- Allow scheduling of DaemonSet on all nodes
+  # - operator: "Exists"
+
+# -- Optional priority class to be used for the google-cas-issuer pods.
+priorityClassName: ""


### PR DESCRIPTION
New values like in https://github.com/cert-manager/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml

* commonLabels
* deploymentAnnotations
* podAnnotations
* podLabels
* nodeSelector
* affinity
* tolerations
* priorityClassName