### PR TITLE
Feat/certtemplate

### DIFF
--- a/api/v1beta1/googlecasissuer_types.go
+++ b/api/v1beta1/googlecasissuer_types.go
@@ -47,6 +47,11 @@ type GoogleCASIssuerSpec struct {
 	// Credentials is a reference to a Kubernetes Secret Key that contains Google Service Account Credentials
 	// +optional
 	Credentials cmmetav1.SecretKeySelector `json:"credentials,omitempty"`
+
+	// CertificateTemplate is specific certificate template to
+	// use. Omit to not specify a template
+	// +optional
+	CertificateTemplate string `json:"certificateTemplate,omitempty"`
 }
 
 // GoogleCASIssuerStatus defines the observed state of GoogleCASIssuer

--- a/deploy/charts/google-cas-issuer/templates/crds/cas-issuer.jetstack.io_googlecasclusterissuers.yaml
+++ b/deploy/charts/google-cas-issuer/templates/crds/cas-issuer.jetstack.io_googlecasclusterissuers.yaml
@@ -48,6 +48,9 @@ spec:
                 certificateAuthorityId:
                   description: CertificateAuthorityId is specific certificate authority to use to sign. Omit in order to load balance across all CAs in the pool
                   type: string
+                certificateTemplate:
+                  description: CertificateTemplate is specific certificate template to use. Omit to not specify a template
+                  type: string
                 credentials:
                   description: Credentials is a reference to a Kubernetes Secret Key that contains Google Service Account Credentials
                   type: object

--- a/deploy/charts/google-cas-issuer/templates/crds/cas-issuer.jetstack.io_googlecasissuers.yaml
+++ b/deploy/charts/google-cas-issuer/templates/crds/cas-issuer.jetstack.io_googlecasissuers.yaml
@@ -48,6 +48,9 @@ spec:
                 certificateAuthorityId:
                   description: CertificateAuthorityId is specific certificate authority to use to sign. Omit in order to load balance across all CAs in the pool
                   type: string
+                certificateTemplate:
+                  description: CertificateTemplate is specific certificate template to use. Omit to not specify a template
+                  type: string
                 credentials:
                   description: Credentials is a reference to a Kubernetes Secret Key that contains Google Service Account Credentials
                   type: object

--- a/pkg/cas/cas.go
+++ b/pkg/cas/cas.go
@@ -74,6 +74,7 @@ func (c *casSigner) Sign(csr []byte, expiry time.Duration) (cert []byte, ca []by
 				Seconds: expiry.Milliseconds() / 1000,
 				Nanos:   0,
 			},
+			CertificateTemplate: c.spec.CertificateTemplate,
 		},
 		RequestId:                     uuid.New().String(),
 		IssuingCertificateAuthorityId: c.spec.CertificateAuthorityId,


### PR DESCRIPTION
Hello,

we have extended the implementation for support of Google CAS Certificate Templates. It can be done by specifying an additional field in the CAS Issuer Type.