### PR TITLE
Allow tests on forks

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,14 +1,13 @@
-name: tests
+# This workflow runs priviledged e2e tests for trusted sources.
+name: e2e-tests
 on:
   push:
-    branches:
-      - main
-  pull_request:
     branches:
       - main
   schedule:
     # At 03:23 on every 3rd day
     - cron: "23 3 */3 * *"
+
 jobs:
   run_tests:
     runs-on: ubuntu-latest
@@ -30,9 +29,6 @@ jobs:
       with:
         workload_identity_provider: 'projects/874174494201/locations/global/workloadIdentityPools/google-cas-issuer-e2e/providers/google-cas-issuer-e2e'
         service_account: 'google-cas-issuer-e2e@jetstack-cas.iam.gserviceaccount.com'
-
-    - name: Run unit tests
-      run: make test
 
     - name: Run e2e tests
       run: make e2e

--- a/.github/workflows/pr_e2e_tests.yml
+++ b/.github/workflows/pr_e2e_tests.yml
@@ -1,0 +1,62 @@
+# This workflow runs priviledged e2e tests for untrusted sources (incomming PRs).
+name: pr-e2e-tests
+on:
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - main
+
+jobs:
+  run_tests:
+    # IMPORTANT: we require the ok-to-test label before running the test!
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.19'
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        # INSECURE, but ok thanks to ok-to-test label.
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+    - id: 'auth'
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        workload_identity_provider: 'projects/874174494201/locations/global/workloadIdentityPools/google-cas-issuer-e2e/providers/google-cas-issuer-e2e'
+        service_account: 'google-cas-issuer-e2e@jetstack-cas.iam.gserviceaccount.com'
+
+    - name: Run e2e tests
+      run: make e2e
+      env:
+        TEST_GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: e2e-logs
+        path: _artifacts/e2e/logs
+
+  # remove the ok-to-test label after the e2e test completed
+  remove-ok-to-test:
+    name: Remove ok-to-test label
+    needs:
+      - run_tests
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test') && always()
+    steps:
+      - name: Remove Label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: 'ok-to-test'
+          fail_on_error: 'false'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,29 @@
+# This workflow runs unpriviledged unit tests.
+name: unit-tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # At 03:23 on every 3rd day
+    - cron: "23 3 */3 * *"
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.19'
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Run unit tests
+      run: make test


### PR DESCRIPTION
more info: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
TLDR: using pull_request_target runs the action in context of the target instead of the fork, thus allowing access to secrets etc.

We prevent malicious code from running by requiring the ok-to-test label before running the e2e test.