### PR TITLE
Set helm chart version to v0.7.0 ready for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Visit the [GitHub releases](https://github.com/jetstack/google-cas-issuer/releas
 and copy the command, e.g.
 
 ```shell
-kubectl apply -f https://github.com/jetstack/google-cas-issuer/releases/download/v0.6.1/google-cas-issuer-v0.6.1.yaml
+kubectl apply -f https://github.com/jetstack/google-cas-issuer/releases/download/v0.7.0/google-cas-issuer-v0.7.0.yaml
 ```
 
 You can then skip to the [Setting up Google Cloud IAM](#setting-up-google-cloud-iam) section.

--- a/deploy/charts/google-cas-issuer/Chart.yaml
+++ b/deploy/charts/google-cas-issuer/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 sources:
 - https://github.com/jetstack/google-cas-issuer
 
-appVersion: v0.6.2
-version: v0.6.2
+appVersion: v0.7.0
+version: v0.7.0

--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -30,7 +30,7 @@ A Helm chart for jetstack/google-cas-issuer
 | deploymentAnnotations | object | `{}` | Optional additional annotations to add to the google-cas-issuer Deployment |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/cert-manager-google-cas-issuer"` | Target image repository. |
-| image.tag | string | `"0.6.2"` | Target image version tag. |
+| image.tag | string | `"0.7.0"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | Optional secrets used for pulling the google-cas-issuer container image. |
 | nodeSelector | object | `{}` | Kubernetes node selector: node labels for pod assignment |
 | podAnnotations | object | `{}` | Optional additional annotations to add to the google-cas-issuer Pods |

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -5,7 +5,7 @@ image:
   # -- Target image repository.
   repository: quay.io/jetstack/cert-manager-google-cas-issuer
   # -- Target image version tag.
-  tag: 0.6.2
+  tag: 0.7.0
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Follow-up of https://github.com/jetstack/google-cas-issuer/pull/96 and https://github.com/jetstack/google-cas-issuer/pull/110 @SgtCoDFish 