### PR TITLE
Add namespace attributes and render for the cert-manager namespace by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         shell: bash
         run: |
           export VERSION=${GITHUB_REF##*/}
-          ./bin/helm template deploy/charts/google-cas-issuer --set image.tag=${VERSION#v} | tee google-cas-issuer-${VERSION}.yaml
+          ./bin/helm template deploy/charts/google-cas-issuer --namespace=cert-manager --set image.tag=${VERSION#v} | tee google-cas-issuer-${VERSION}.yaml
       -
         name: create release
         id: create_release

--- a/deploy/charts/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/charts/google-cas-issuer/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cert-manager-google-cas-issuer.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-google-cas-issuer.labels" . | indent 4 }}
   {{- with .Values.deploymentAnnotations }}

--- a/deploy/charts/google-cas-issuer/templates/role.yaml
+++ b/deploy/charts/google-cas-issuer/templates/role.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "cert-manager-google-cas-issuer.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-google-cas-issuer.labels" . | indent 4 }}
 rules:

--- a/deploy/charts/google-cas-issuer/templates/rolebinding.yaml
+++ b/deploy/charts/google-cas-issuer/templates/rolebinding.yaml
@@ -2,6 +2,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "cert-manager-google-cas-issuer.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-google-cas-issuer.labels" . | indent 4 }}
 roleRef:

--- a/deploy/charts/google-cas-issuer/templates/serviceaccount.yaml
+++ b/deploy/charts/google-cas-issuer/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "cert-manager-google-cas-issuer.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "cert-manager-google-cas-issuer.labels" . | indent 4 }}
   annotations:


### PR DESCRIPTION
Currently, the static manifest installs google-cas-issuer in the default namespace.
It is not possible to pass a namespace to `kubectl -n .... apply`, because the role binding namespaces will be wrong.
For that reason, we should add namespaces to all resources and set the default namespace to the cert-manager namespace ( seems like a good default ).

fixes https://github.com/jetstack/google-cas-issuer/issues/108