### PR TITLE
re-adding required clusterrole permission

### DIFF
--- a/deploy/charts/google-cas-issuer/templates/clusterrole.yaml
+++ b/deploy/charts/google-cas-issuer/templates/clusterrole.yaml
@@ -63,6 +63,7 @@ rules:
   - certificaterequests/status
   verbs:
   - patch
+  - update
 
 - apiGroups:
   - certificates.k8s.io


### PR DESCRIPTION
We discovered this issue as it took down our production system when certs we unable to renew without the explicit permission to update the certificaterequests/status resource.