### PR TITLE
feat: allow creating or reusing an existing sa

### DIFF
--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -19,7 +19,7 @@ This option decides if the CRDs should be installed as part of the Helm installa
 > true
 > ```
 
-This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources  
+This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources
 (Certificates, Issuers, ...) will be removed too by the garbage collector.
 #### **replicaCount** ~ `number`
 > Default value:
@@ -151,7 +151,7 @@ Optional additional labels to add to the google-cas-issuer Pods
 > {}
 > ```
 
-Kubernetes pod resource requests/limits for google-cas-issuer.  
+Kubernetes pod resource requests/limits for google-cas-issuer.
 For example:
 
 ```yaml
@@ -168,7 +168,7 @@ requests:
 > {}
 > ```
 
-Kubernetes node selector: node labels for pod assignment  
+Kubernetes node selector: node labels for pod assignment
 For example:
 
 ```yaml
@@ -180,7 +180,7 @@ kubernetes.io/os: linux
 > {}
 > ```
 
-Kubernetes affinity: constraints for pod assignment  
+Kubernetes affinity: constraints for pod assignment
 For example:
 
 ```yaml
@@ -199,8 +199,8 @@ nodeAffinity:
 > []
 > ```
 
-Kubernetes pod tolerations for google-cas-issuer  
-For example:  
+Kubernetes pod tolerations for google-cas-issuer
+For example:
  - operator: "Exists"
 #### **priorityClassName** ~ `string`
 > Default value:

--- a/deploy/charts/google-cas-issuer/templates/_helpers.tpl
+++ b/deploy/charts/google-cas-issuer/templates/_helpers.tpl
@@ -42,3 +42,14 @@ See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linke
 {{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cert-manager-google-cas-issuer.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cert-manager-google-cas-issuer.name" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/google-cas-issuer/templates/clusterrolebinding.yaml
+++ b/deploy/charts/google-cas-issuer/templates/clusterrolebinding.yaml
@@ -10,7 +10,7 @@ roleRef:
   name: {{ include "cert-manager-google-cas-issuer.name" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "cert-manager-google-cas-issuer.name" . }}
+  name: {{ include "cert-manager-google-cas-issuer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 {{- if .Values.app.approval.enabled }}

--- a/deploy/charts/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/charts/google-cas-issuer/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "cert-manager-google-cas-issuer.name" . }}
+      serviceAccountName: {{ include "cert-manager-google-cas-issuer.serviceAccountName" . }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/deploy/charts/google-cas-issuer/templates/rolebinding.yaml
+++ b/deploy/charts/google-cas-issuer/templates/rolebinding.yaml
@@ -11,5 +11,5 @@ roleRef:
   name: {{ include "cert-manager-google-cas-issuer.name" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "cert-manager-google-cas-issuer.name" . }}
+  name: {{ include "cert-manager-google-cas-issuer.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/deploy/charts/google-cas-issuer/templates/serviceaccount.yaml
+++ b/deploy/charts/google-cas-issuer/templates/serviceaccount.yaml
@@ -1,9 +1,10 @@
+{{ if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cert-manager-google-cas-issuer.name" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "cert-manager-google-cas-issuer.serviceAccountName" . }}
   labels:
 {{ include "cert-manager-google-cas-issuer.labels" . | indent 4 }}
   annotations:
 {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -37,11 +37,16 @@ imagePullSecrets: []
 commonLabels: {}
 
 serviceAccount:
-  # Optional annotations to add to the service account
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- The name used to create the service account or the name of an existing service account to use if not creating one.
+  # if create is false, this name is required or the default service account will be used.
+  name: ""
+  # -- Optional annotations to add to the service account
   annotations: {}
 
 app:
-  # Verbosity of google-cas-issuer logging.
+  # -- Verbosity of google-cas-issuer logging.
   logLevel: 1 # 1-5
 
   # Handle RBAC permissions for approving Google CAS issuer
@@ -62,9 +67,9 @@ app:
     #   name: cert-manager-approver-policy
     #   namespace: cert-manager
     subjects:
-    - kind: ServiceAccount
-      name: cert-manager
-      namespace: cert-manager
+      - kind: ServiceAccount
+        name: cert-manager
+        namespace: cert-manager
 
   # metrics controls exposing google-cas-issuer metrics.
   metrics:


### PR DESCRIPTION
Hi,
here is a short PR that allows the google cas container deployed with the helm chart to reuse an existing ServiceAccount.

closes #133 