### PR TITLE
Use v-prefixed image tags

### DIFF
--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -27,8 +27,7 @@ go_manager_mod_dir := .
 go_manager_ldflags := -X $(repo_name)/pkg/internal/version.AppVersion=$(VERSION) -X $(repo_name)/pkg/internal/version.GitCommit=$(GITCOMMIT)
 oci_manager_base_image_flavor := static
 oci_manager_image_name := quay.io/jetstack/cert-manager-google-cas-issuer
-# google-cas-issuer for some reason doesn't use the v prefix in its tags
-oci_manager_image_tag := $(VERSION:v%=%)
+oci_manager_image_tag := $(VERSION)
 oci_manager_image_name_development := cert-manager.local/cert-manager-google-cas-issuer
 
 deploy_name := google-cas-issuer


### PR DESCRIPTION
[Similarly to openshift-routes](https://github.com/cert-manager/openshift-routes/releases/tag/v0.6.0), I would like to change the image tag prefix to "v". This should not affect end-users much, they probably install openshift-routes using the Helm chart which will be updated too. It might affect users that have custom mirroring logic to mirror based on non-"v"-prefixed tags (unlikely).

  ```diff
  -quay.io/jetstack/cert-manager-google-cas-issuer:0.8.0
  +quay.io/jetstack/cert-manager-google-cas-issuer:v0.9.0
  ```