### PR TITLE
Add maintenance mode notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains an [external Issuer](https://cert-manager.io/docs/contr
 for cert-manager that issues certificates using [Google Cloud
 Certificate Authority Service (CAS)](https://cloud.google.com/certificate-authority-service/), using managed private CAs to issue certificates.
 
+> [!IMPORTANT]
+> The Google CAS Issuer project is currently in maintenance mode. We will continue to provide support for bug fixes and security updates, but no new major features are planned. We are looking for maintainers/ partners (eg. the Google CAS team) to continue the development of this project and take some of the maintainership responsibilities. If you are interested, please reach out to us on the [`cert-manager-dev` Slack via @cert-manager-maintainers](https://groups.google.com/forum/#!forum/cert-manager-dev).
+
+
 > [!IMPORTANT]  
 > Starting from version v0.9.0, the docker image for the Google CAS Issuer controller is tagged with a v-prefix (v0.9.0 instead of 0.9.0). The helm chart for v0.9.0 will also refer to this image tag. Make sure to update your image replication rules if necessary.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Certificate Authority Service (CAS)](https://cloud.google.com/certificate-author
 > [!IMPORTANT]
 > The Google CAS Issuer project is currently in maintenance mode. We will continue to provide support for bug fixes and security updates, but no new major features are planned. We are looking for maintainers/ partners (eg. the Google CAS team) to continue the development of this project and take some of the maintainership responsibilities. If you are interested, please reach out to us on the [`cert-manager-dev` Slack via @cert-manager-maintainers](https://groups.google.com/forum/#!forum/cert-manager-dev).
 
+> [!IMPORTANT]
+> The `GoogleCASIssuer` and `GoogleCASClusterIssuer` CRDs are part of the `cas-issuer.jetstack.io` API group. This `jetstack.io` API group is used for legacy reasons and will not be immediately changed to preserve backwards compatibility. This project however is no longer maintained or owned by Jetstack, instead it is maintained by the cert-manager team/ community.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Starting from version v0.9.0, the docker image for the Google CAS Issuer controller is tagged with a v-prefix (v0.9.0 instead of 0.9.0). The helm chart for v0.9.0 will also refer to this image tag. Make sure to update your image replication rules if necessary.
 
 ## Getting started


### PR DESCRIPTION
Add a notice that clarifies that we are maintaining this project in "maintenance mode", meaning that we are not looking for major new features. Instead, we aim to keep the project up-to-date and fix bugs.

The PR also adds a second notice to explain that we are only using jetstack.io as API group for legacy reasons. This notice will be useful when we move the repo to the cert-manager org.

These changes were suggested here: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1723659566436439?thread_ts=1723627155.440739&cid=CDEQJ0Q8M