### PR TITLE
chore: add existing securityContext settings to values

### DIFF
--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -213,5 +213,28 @@ For example:
 > ```
 
 Optional priority class to be used for the google-cas-issuer pods.
+#### **securityContext** ~ `object`
+> Default value:
+> ```yaml
+> runAsNonRoot: true
+> seccompProfile:
+>   type: RuntimeDefault
+> ```
+
+Pod Security Context.  
+For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
+#### **containerSecurityContext** ~ `object`
+> Default value:
+> ```yaml
+> allowPrivilegeEscalation: false
+> capabilities:
+>   drop:
+>     - ALL
+> readOnlyRootFilesystem: true
+> ```
+
+Container Security Context to be set on the controller component container. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/charts/google-cas-issuer/templates/deployment.yaml
@@ -27,10 +27,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.securityContext }}
       securityContext:
-        runAsNonRoot: true
-        seccompProfile: { type: RuntimeDefault }
-
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -53,12 +53,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-
+        {{- with .Values.containerSecurityContext }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities: { drop: ["ALL"] }
-          readOnlyRootFilesystem: true
-
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/google-cas-issuer/values.schema.json
+++ b/deploy/charts/google-cas-issuer/values.schema.json
@@ -12,6 +12,9 @@
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
+        "containerSecurityContext": {
+          "$ref": "#/$defs/helm-values.containerSecurityContext"
+        },
         "crds": {
           "$ref": "#/$defs/helm-values.crds"
         },
@@ -47,6 +50,9 @@
         },
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/helm-values.securityContext"
         },
         "serviceAccount": {
           "$ref": "#/$defs/helm-values.serviceAccount"
@@ -149,6 +155,19 @@
     "helm-values.commonLabels": {
       "default": {},
       "description": "Labels to apply to all resources",
+      "type": "object"
+    },
+    "helm-values.containerSecurityContext": {
+      "default": {
+        "allowPrivilegeEscalation": false,
+        "capabilities": {
+          "drop": [
+            "ALL"
+          ]
+        },
+        "readOnlyRootFilesystem": true
+      },
+      "description": "Container Security Context to be set on the controller component container. For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
       "type": "object"
     },
     "helm-values.crds": {
@@ -259,6 +278,16 @@
     "helm-values.resources": {
       "default": {},
       "description": "Kubernetes pod resource requests/limits for google-cas-issuer.\nFor example:\nlimits:\n  cpu: 100m\n  memory: 128Mi\nrequests:\n  cpu: 100m\n  memory: 128Mi",
+      "type": "object"
+    },
+    "helm-values.securityContext": {
+      "default": {
+        "runAsNonRoot": true,
+        "seccompProfile": {
+          "type": "RuntimeDefault"
+        }
+      },
+      "description": "Pod Security Context.\nFor more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).",
       "type": "object"
     },
     "helm-values.serviceAccount": {

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -115,6 +115,24 @@ tolerations: []
 # Optional priority class to be used for the google-cas-issuer pods.
 priorityClassName: ""
 
+# Pod Security Context.
+# For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+# +docs:property
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container Security Context to be set on the controller component container.
+# For more information, see [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
+# +docs:property
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+
 # Override the "cert-manager-google-cas-issuer.name" value.
 # +docs:property
 # nameOverride: "my-google-cas-issuer"


### PR DESCRIPTION
To allow values to be set that satisfy the [restricted Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)

Based on https://github.com/cert-manager/google-cas-issuer/pull/115