### PR TITLE
Migrate from legacy Helm to OCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ If not already running in the cluster, install cert-manager by following the [of
 ### Installing Google CAS Issuer for cert-manager
 
 ```shell
-helm repo add jetstack https://charts.jetstack.io --force-update
-helm upgrade -i cert-manager-google-cas-issuer jetstack/cert-manager-google-cas-issuer -n cert-manager --wait
+helm upgrade -i cert-manager-google-cas-issuer oci://quay.io/jetstack/charts/cert-manager-google-cas-issuer -n cert-manager --wait
 ```
 
 Or alternatively, assuming that you have installed cert-manager in the `cert-manager` namespace, you can use a single kubectl

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,11 +2,12 @@
 
 ## Schedule
 
-The release schedule for this project is ad-hoc. Given the pre-1.0 status of the project we do not have a fixed release cadence. However if a vulnerability is discovered we will respond in accordance with our [security policy](https://github.com/cert-manager/community/blob/main/SECURITY.md) and this response may include a release.
+The release schedule for this project is ad-hoc. Given the pre-1.0 status of the project we do not have a fixed release cadence.
+However, if a vulnerability is discovered we will respond in accordance with our [security policy](https://github.com/cert-manager/community/blob/main/SECURITY.md) and this response may include a release.
 
 ## Process
 
-There is a semi-automated release process for this project. When you create a Git tag with a tagname that has a `v` prefix and push it to GitHub it will trigger the [release workflow].
+There is a semi-automated release process for this project. When you create a Git tag with a tag name that has a `v` prefix and push it to GitHub it will trigger the [release workflow].
 
 The release process for this repo is documented below:
 
@@ -18,21 +19,22 @@ The release process for this repo is documented below:
    ```
 2. A GitHub action will see the new tag and do the following:
     - Build and publish any container images
-    - Build and publish the Helm chart
+    - Build and publish the OCI Helm chart
     - Create a draft GitHub release
-3. Wait for the PR to be merged and wait for OCI Helm chart to propagate and become available from https://charts.jetstack.io (this might take a few hours).
-4. Visit the [releases page], edit the draft release, click "Generate release notes", then edit the notes to add the following to the top
+3. Visit the [releases page], edit the draft release, click "Generate release notes", then edit the notes to add the following to the top
     ```
     google-cas-issuer enables issuing X.509 certificates using Google CA Service
     ```
-5. Publish the release.
+4. Publish the release.
 
 ## Artifacts
 
 This repo will produce the following artifacts each release. For documentation on how those artifacts are produced see the "Process" section.
 
-- *Container Images* - Container images for the are published to . 
-- *Helm chart* - An official Helm chart is maintained within this repo and published to `quay.io/jetstack` and `charts.jetstack.io` on each release.
+- *Container Images* - Container images for the project are published to `quay.io/jetstack`.
+- *Helm chart* - An official Helm chart is maintained within this repo and published to `quay.io/jetstack` on each release.
+    - The chart is also published to the legacy HTTP Helm repository at `https://charts.jetstack.io` (maintained by Venafi).
+      Publishing to the legacy repo depends on a PR to be merged in a closed Venafi repo, and might be delayed.
 
 [release workflow]: https://github.com/cert-manager/google-cas-issuer/actions/workflows/release.yaml
 [releases page]: https://github.com/cert-manager/google-cas-issuer/releases

--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -15,13 +15,13 @@
 .PHONY: e2e-setup-cert-manager
 e2e-setup-cert-manager: | kind-cluster $(NEEDS_HELM) $(NEEDS_KUBECTL)
 	$(HELM) upgrade \
+		cert-manager oci://quay.io/jetstack/charts/cert-manager \
 		--install \
 		--create-namespace \
 		--wait \
 		--version $(cert_manager_version) \
 		--namespace cert-manager \
-		--repo https://charts.jetstack.io \
-		--set installCRDs=true \
+		--set crds.enabled=true \
 		--set image.repository=$(quay.io/jetstack/cert-manager-controller.REPO) \
 		--set image.tag=$(quay.io/jetstack/cert-manager-controller.TAG) \
 		--set image.pullPolicy=Never \
@@ -34,7 +34,7 @@ e2e-setup-cert-manager: | kind-cluster $(NEEDS_HELM) $(NEEDS_KUBECTL)
 		--set startupapicheck.image.repository=$(quay.io/jetstack/cert-manager-startupapicheck.REPO) \
 		--set startupapicheck.image.tag=$(quay.io/jetstack/cert-manager-startupapicheck.TAG) \
 		--set startupapicheck.image.pullPolicy=Never \
-		cert-manager cert-manager >/dev/null
+		>/dev/null
 
 # The "install" target can be run on its own with any currently active cluster,
 # we can't use any other cluster then a target containing "test-e2e" is run.


### PR DESCRIPTION
This PR mimics the changes done in https://github.com/cert-manager/approver-policy/pull/748 to update our release process documentation. In addition, I have also migrated other references to the legacy https Helm chart repo to OCI.