### PR TITLE
Replace math/rand with math/rand/v2

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,10 +17,8 @@ limitations under the License.
 package cmd
 
 import (
-	"math/rand"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -44,9 +42,6 @@ func Execute() {
 func init() {
 	// Check environment variables for config
 	cobra.OnInitialize(flagsFromEnv)
-
-	// initialise psuedorandom numbers for cert IDs
-	rand.Seed(time.Now().UnixNano())
 }
 
 // flagsFromEnv allows flags to be set from environment variables.

--- a/pkg/controllers/signer.go
+++ b/pkg/controllers/signer.go
@@ -23,7 +23,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"time"
 

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -17,17 +17,15 @@ limitations under the License.
 package util
 
 import (
-	"math/rand"
-	"time"
+	"math/rand/v2"
 )
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyz")
 
 func RandomString(length int) string {
-	testRand := rand.New(rand.NewSource(time.Now().UnixNano()))
 	randomString := make([]rune, length)
 	for i := range randomString {
-		randomString[i] = letters[testRand.Intn(len(letters))]
+		randomString[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(randomString)
 }


### PR DESCRIPTION
Replace the deprecated `math/rand` package with `math/rand/v2` across the codebase. This removes the manual `rand.Seed` call in `cmd/cmd.go` since `math/rand/v2` is automatically seeded, replaces `rand.Int()` with `rand.IntN()` in the signer, and simplifies `RandomString` in the e2e test utility.