### PR TITLE
fix: rename image helper to avoid umbrella chart conflicts

### DIFF
--- a/deploy/charts/google-cas-issuer/templates/_helpers.tpl
+++ b/deploy/charts/google-cas-issuer/templates/_helpers.tpl
@@ -35,7 +35,7 @@ IMPORTANT: This function is standarized across all charts in the cert-manager GH
 Any changes to this function should also be made in cert-manager, trust-manager, approver-policy, ...
 See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linked PRs.
 */}}
-{{- define "image" -}}
+{{- define "cert-manager-google-cas-issuer.image" -}}
 {{- $defaultTag := index . 1 -}}
 {{- with index . 0 -}}
 {{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}

--- a/deploy/charts/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/charts/google-cas-issuer/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "cert-manager-google-cas-issuer.name" . }}
-        image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
+        image: "{{ template "cert-manager-google-cas-issuer.image" (tuple .Values.image $.Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.app.metrics.port }}


### PR DESCRIPTION
Part of a group of PRs aiming to fix the issues reported here:

https://github.com/cert-manager/google-cas-issuer/issues/487

https://github.com/cert-manager/trust-manager/issues/908