### PR TITLE
feat(chart): expose topologySpreadConstraints in the google-cas-issuer chart

### DIFF
--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -243,6 +243,26 @@ nodeAffinity:
 Kubernetes pod tolerations for google-cas-issuer  
 For example:  
  - operator: "Exists"
+#### **topologySpreadConstraints** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+List of Kubernetes TopologySpreadConstraints.  
+  
+For example:
+
+```yaml
+topologySpreadConstraints:
+- maxSkew: 2
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: controller
+```
 #### **priorityClassName** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/google-cas-issuer/templates/deployment.yaml
+++ b/deploy/charts/google-cas-issuer/templates/deployment.yaml
@@ -74,3 +74,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/google-cas-issuer/values.schema.json
+++ b/deploy/charts/google-cas-issuer/values.schema.json
@@ -59,6 +59,9 @@
         },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
+        },
+        "topologySpreadConstraints": {
+          "$ref": "#/$defs/helm-values.topologySpreadConstraints"
         }
       },
       "type": "object"
@@ -313,6 +316,12 @@
     "helm-values.tolerations": {
       "default": [],
       "description": "Kubernetes pod tolerations for google-cas-issuer\nFor example:\n - operator: \"Exists\"",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.topologySpreadConstraints": {
+      "default": [],
+      "description": "List of Kubernetes TopologySpreadConstraints.\n\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/instance: cert-manager\n      app.kubernetes.io/component: controller",
       "items": {},
       "type": "array"
     }

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -149,6 +149,19 @@ affinity: {}
 #  - operator: "Exists"
 tolerations: []
 
+# List of Kubernetes TopologySpreadConstraints.
+#
+# For example:
+#   topologySpreadConstraints:
+#   - maxSkew: 2
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/instance: cert-manager
+#         app.kubernetes.io/component: controller
+topologySpreadConstraints: []
+
 # Optional priority class to be used for the google-cas-issuer pods.
 priorityClassName: ""
 


### PR DESCRIPTION
## What

Exposes a `topologySpreadConstraints` value in the google-cas-issuer Helm chart and wires it into the Deployment.

## Why

Several sibling cert-manager charts already let operators set `topologySpreadConstraints` on the workload (trust-manager, csi-driver-spiffe, approver-policy and others), using the same value, comment and template idiom. google-cas-issuer did not expose it, so operators who run more than one replica and want to spread pods across zones/nodes had to fork the chart.

This adds the value with the same wording and `{{- with .Values.topologySpreadConstraints }}` idiom as the sibling charts.

## Behaviour

Default is `[]`, so the rendered Deployment is unchanged. Verified:
- `helm template` default → no `topologySpreadConstraints` rendered.
- `helm template --set topologySpreadConstraints[0]...` → renders correctly.
- `values.schema.json` and `README.md` regenerated via `make generate-helm-schema generate-helm-docs`.
- `make verify-helm-values`, `verify-helm-lint` pass.

```release-note
The google-cas-issuer Helm chart now supports setting `topologySpreadConstraints` on the deployment.
```
