### PR TITLE
feat(chart): allow `enabled` key in values schema

### DIFF
--- a/deploy/charts/google-cas-issuer/README.md
+++ b/deploy/charts/google-cas-issuer/README.md
@@ -6,10 +6,6 @@
 
 <!-- AUTO-GENERATED -->
 
-#### **nameOverride** ~ `string`
-
-Override the "cert-manager-google-cas-issuer.name" value.
-
 #### **imageRegistry** ~ `string`
 > Default value:
 > ```yaml
@@ -250,5 +246,9 @@ For example:
 > ```
 
 Optional priority class to be used for the google-cas-issuer pods.
+#### **nameOverride** ~ `string`
+
+Override the "cert-manager-google-cas-issuer.name" value.
+
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/google-cas-issuer/values.linter.exceptions
+++ b/deploy/charts/google-cas-issuer/values.linter.exceptions
@@ -1,0 +1,1 @@
+value missing from templates: enabled

--- a/deploy/charts/google-cas-issuer/values.schema.json
+++ b/deploy/charts/google-cas-issuer/values.schema.json
@@ -18,6 +18,9 @@
         "deploymentAnnotations": {
           "$ref": "#/$defs/helm-values.deploymentAnnotations"
         },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.enabled"
+        },
         "global": {
           "$ref": "#/$defs/helm-values.global"
         },
@@ -191,6 +194,11 @@
       "default": {},
       "description": "Optional additional annotations to add to the google-cas-issuer Deployment",
       "type": "object"
+    },
+    "helm-values.enabled": {
+      "default": true,
+      "description": "Field to optionally disable installation of the chart when wrapping it as a dependency in another chart.\nThis matches the Helm best practices:\nhttps://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags",
+      "type": "boolean"
     },
     "helm-values.global": {
       "description": "Global values shared across all (sub)charts"

--- a/deploy/charts/google-cas-issuer/values.yaml
+++ b/deploy/charts/google-cas-issuer/values.yaml
@@ -155,3 +155,10 @@ priorityClassName: ""
 # Override the "cert-manager-google-cas-issuer.name" value.
 # +docs:property
 # nameOverride: "my-google-cas-issuer"
+
+# Field to optionally disable installation of the chart when wrapping it as a
+# dependency in another chart.
+# This matches the Helm best practices:
+# https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags
+# +docs:hidden
+enabled: true


### PR DESCRIPTION
## What

Adds a hidden top-level `enabled: true` value so google-cas-issuer can be wrapped as a dependency with the standard Helm `condition:` toggle.

## Why

The chart ships a strict `values.schema.json` (`additionalProperties: false`). Umbrella charts disable an optional subchart with:

```yaml
dependencies:
  - name: cert-manager-google-cas-issuer
    condition: cert-manager-google-cas-issuer.enabled
```

…which requires an `enabled` key in the subchart's values. Without it, `helm template --set enabled=false` fails:

```
Error: ... at '': additional properties 'enabled' not allowed
```

This mirrors the exact pattern already shipped in the sibling **trust-manager** and **cert-manager** charts (hidden `enabled` placeholder + a `values.linter.exceptions` entry, since the key is consumed by Helm's subchart condition rather than the chart templates).

## Verification

- Before: `helm template --set enabled=false` → schema rejection. After: accepted.
- Default render unchanged (1 Deployment); `helm lint`, `make verify-helm-values`, `verify-helm-lint` pass; `values.schema.json` + `README.md` regenerated.

Fixes #361
